### PR TITLE
5 jr

### DIFF
--- a/application/src/app/components/analysis/analysis.component.html
+++ b/application/src/app/components/analysis/analysis.component.html
@@ -31,6 +31,14 @@
                 </div>
             </div>
         </div>
+        <div class="tile is-ancestor total-row">
+            <div class="tile is-3 is-vertical time-cont">
+                <h2>Total Time</h2>
+            </div>
+            <div class="tile is-3 is-vertical" *ngFor="let runner of runners">
+                <p class="total-time">{{ parseTime(runner.totalTime) }}</p>
+            </div>
+        </div>
     </div>
     
 </div>

--- a/application/src/app/components/analysis/analysis.component.html
+++ b/application/src/app/components/analysis/analysis.component.html
@@ -25,8 +25,8 @@
                 <p *ngFor="let segment of segmentTypes.uncommon">{{ findSegTitle(segment) }}</p>
             </div>
             <div class="tile is-3 is-vertical" *ngFor="let runner of runners">
+                <h2>{{ runner.name }}</h2>
                 <div *ngFor="let segment of segmentTypes.uncommon">
-                    <h2>{{ runner.name }}</h2>
                     <p>{{ findRunnerTimeForSegment(runner.id, segment) ? parseTime(findRunnerTimeForSegment(runner.id, segment)) : 'N/A' }}</p>
                 </div>
             </div>

--- a/application/src/app/components/analysis/analysis.component.scss
+++ b/application/src/app/components/analysis/analysis.component.scss
@@ -15,3 +15,19 @@ h2 {
 .analysis-behind {
     background-color: #800;
 }
+
+.total-row {
+    margin-top: 40px;
+
+    h2 {
+        margin: 0;
+    }
+}
+
+.total-time {
+    font-size: 30px;
+}
+
+.time-cont {
+    justify-content: center;
+}

--- a/application/src/app/components/analysis/analysis.component.ts
+++ b/application/src/app/components/analysis/analysis.component.ts
@@ -70,15 +70,14 @@ export class AnalysisComponent implements OnInit, OnDestroy {
             // loop through each segment 
             runner.segments.forEach(segment => {
                 // has another runner done this segment and beat it?
-                if (this.bestTimes[segment.locId] && segment.time < this.bestTimes[segment.locId]) {
+                if (this.bestTimes[segment.locId] && this.findRunnerTimeForSegment(runner.id, segment.locId) < this.bestTimes[segment.locId]) {
                     // if so, it's the new best time
-                    this.bestTimes[segment.locId] = segment.time;
+                    this.bestTimes[segment.locId] = this.findRunnerTimeForSegment(runner.id, segment.locId);
                 } else if (!this.bestTimes[segment.locId]) {
                     //also add the time if a previous one doesnt exist
-                    this.bestTimes[segment.locId] = segment.time;
+                    this.bestTimes[segment.locId] = this.findRunnerTimeForSegment(runner.id, segment.locId);
                 }
             });
         });
-        console.log('best times', this.bestTimes)
     }
 }

--- a/application/src/app/components/analysis/analysis.component.ts
+++ b/application/src/app/components/analysis/analysis.component.ts
@@ -8,6 +8,7 @@ import { ISegmentTypes } from 'src/app/interfaces/segment-type.interface';
 import { SegmentListService } from 'src/app/services/segment-list/segment-list.service';
 import { ISegmentListItem } from 'src/app/interfaces/segment-list-item.interface';
 import { ParseTime } from 'src/app/helpers/parse-time';
+import { SegmentFormComponent } from '../common/segment-form/segment-form.component';
 
 @Component({
     selector: 'fe-comp-analysis',
@@ -43,7 +44,14 @@ export class AnalysisComponent implements OnInit, OnDestroy {
 
     findRunnerTimeForSegment(runnerId: number, segId:number) {
         if (this.runners.find(runner => runner.id === runnerId).segments.find(segment => segment.locId === segId)) {
-            return this.runners.find(runner => runner.id === runnerId).segments.find(segment => segment.locId === segId).time;
+            let timeSum: number = 0;
+            const targetRunner: IRunner = this.runners.find(runner => runner.id === runnerId);
+            targetRunner.segments.forEach(segment => {
+                if (segment.locId === segId) {
+                    timeSum += segment.time;
+                }
+            })
+            return timeSum;
         }
         return null;
     }

--- a/application/src/app/components/main/runner-list/runner-detail/runner-detail.component.html
+++ b/application/src/app/components/main/runner-list/runner-detail/runner-detail.component.html
@@ -1,11 +1,15 @@
 <div class="runner-detail-container">
-    <div *ngIf="runner">
-        <div class="detail-segment-container" *ngFor="let segment of runner.segments">
-            <p>{{segment.name}}</p>
-            <p>{{parseTime(segment.time)}}</p>
-            <div>
-                <button class="button is-primary" (click)="toggleEdit(segment.id)">Edit</button>
-                <button class="button is-danger" (click)="toggleDelete(segment.id)">Delete</button>
+    <div *ngIf="runner container">
+        <div class="detail-segment-container tile is-ancestor" *ngFor="let segment of runner.segments">
+            <div class="tile is-4">
+                <p>{{segment.name}}</p>
+            </div>
+            <div class="tile is-4 detail-mid">
+                <p>{{parseTime(segment.time)}}</p>
+            </div>
+            <div class="tile is-4 detail-end">
+                <button class="button is-primary is-small" (click)="toggleEdit(segment.id)">Edit</button>
+                <button class="button is-danger is-small" (click)="toggleDelete(segment.id)">Delete</button>
             </div>
         </div>
         <div *ngIf="showEditForm">

--- a/application/src/app/components/main/runner-list/runner-detail/runner-detail.component.scss
+++ b/application/src/app/components/main/runner-list/runner-detail/runner-detail.component.scss
@@ -1,5 +1,19 @@
 .detail-segment-container {
-    padding: 20px;
+    padding: 5px;
     display: flex;
     justify-content: space-between;
+
+    &:first-child {
+        margin-top: 20px;
+    }
+
+    .detail-mid {
+        display: flex;
+        justify-content: center;
+    }
+
+    .detail-end {
+        display: flex;
+        justify-content: flex-end;
+    }
 }

--- a/application/src/app/helpers/parse-time.ts
+++ b/application/src/app/helpers/parse-time.ts
@@ -4,7 +4,7 @@ export const ParseTime = (totalSecs: number) :string => {
     let hrs: number = 0;
 
     secs = totalSecs % 60;
-    mins = Math.floor(totalSecs / 60);
+    mins = Math.floor(totalSecs / 60) % 60;
     hrs = Math.floor(totalSecs / 60 / 60);
 
     const secString:string = secs < 10 ? `0${secs}` : secs.toString();


### PR DESCRIPTION
Handles #5 and #2 along with some fixes:

Fixes:
- Times over an hour are now displayed properly instead of "1:62:02" for an hour, 2 minutes and 2 seconds
- Multiple entries with the same ID are properly added on the analysis screen. (#5)
- The runners name is no longer repeated after every segment in the uncommon list.
- Runner detail (view/edit segments) is properly aligned and shrunk a bit)
- The analysis page now shows total time for each runner on the bottom.